### PR TITLE
fix(wizard): import github organisation with space in the name

### DIFF
--- a/src/app/space-wizard/services/fabric8-app-generator-configurator.service.ts
+++ b/src/app/space-wizard/services/fabric8-app-generator-configurator.service.ts
@@ -124,19 +124,6 @@ export class AppGeneratorConfiguratorService {
         }
         break;
       }
-      case 'gitorganisation': {
-        if ( !Array.isArray(input.value) ) {
-          let value: string = input.value || '';
-          if ( value ) {
-            // convert to lower case
-            value = value.trim().toLowerCase();
-            // remove white space
-            value = value.replace(/\s+/g, '');
-            input.value = value;
-          }
-        }
-        break;
-      }
       default: {
         break;
       }


### PR DESCRIPTION
Fixes https://github.com/fabric8-ui/fabric8-platform/issues/1549 

since https://github.com/fabric8io/fabric8-generator/commit/b2ad1f11db56c42c799ce7606d6f5cff78d8336b has been merge on forge add-on remove UI hack to fix that issue